### PR TITLE
Fix for System Menu Styles for Gnome 48

### DIFF
--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -131,14 +131,9 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   }
 
   .quick-toggle-separator {
-    width: 1px;
-    // background-color: ?
-  }
-
-  &:checked {
-    .quick-toggle-separator {
-      // background-color: ?
-    }
+    width: 0px;
+    opacity: 0;
+    visibility: hidden;
   }
 }
 

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -89,7 +89,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   }
 
   .quick-toggle-menu-button {
-    background-color: $secondary-fill !important;
+    background-color: rgba($text, 0.06) !important;
     padding: $space-size $space-size * 1.75;
     border: none !important;
 
@@ -99,16 +99,16 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     }
 
     &:hover {
-      background-color: $divider !important;
+      background-color: rgba($text, 0.12) !important;
     }
 
     &:active {
-      background-color: $track !important;
+      background-color: rgba($text, 0.24) !important;
     }
 
     &:checked {
       background-color: $primary !important;
-      color: on($primary);
+      color: on($primary) !important;
 
       &:focus {
         // background-color: ?
@@ -117,12 +117,12 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
 
       &:hover {
         background-color: mix($text, $primary, 10%) !important;
-        color: on($primary);
+        color: on($primary) !important;
       }
 
       &:active {
         background-color: mix($text, $primary, 20%) !important;
-        color: on($primary);
+        color: on($primary) !important;
       }
     }
 

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -21,7 +21,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   spacing-columns: $space-size * 2;
 }
 
-.quick-toggle, .quick-menu-toggle {
+.quick-toggle, .quick-toggle-has-menu {
   border-radius: $circular-radius;
   min-width: if($compact == 'false', 12em, 10.5em);
   max-width: if($compact == 'false', 12em, 10.5em);
@@ -74,7 +74,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   .quick-toggle-icon { icon-size: $base-icon-size; }
 }
 
-.quick-menu-toggle {
+.quick-toggle-has-menu {
   .quick-toggle {
     min-width: auto;
     max-width: auto;
@@ -88,10 +88,15 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     &:rtl:last-child { border-radius: $circular-radius; }
   }
 
-  .quick-toggle-arrow {
+  .quick-toggle-menu-button {
     background-color: $secondary-fill !important;
     padding: $space-size $space-size * 1.75;
     border: none !important;
+
+    &:focus {
+      // background-color: ?
+      // color: ?
+    }
 
     &:hover {
       background-color: $divider !important;
@@ -104,6 +109,11 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     &:checked {
       background-color: $primary !important;
       color: on($primary);
+
+      &:focus {
+        // background-color: ?
+        // color: ?
+      }
 
       &:hover {
         background-color: mix($text, $primary, 10%) !important;
@@ -118,6 +128,17 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
 
     &:ltr { border-radius: 0 $circular-radius $circular-radius 0; }
     &:rtl { border-radius: $circular-radius 0 0 $circular-radius; }
+  }
+
+  .quick-toggle-separator {
+    width: 1px;
+    // background-color: ?
+  }
+
+  &:checked {
+    .quick-toggle-separator {
+      // background-color: ?
+    }
   }
 }
 


### PR DESCRIPTION
This is a fix for #514 and #516. The fix does work overall, but it has some coloring issues.

Any opinion or help here would be appreciated. You can find all changes for Gnome 48 themes on [this diff](https://gitlab.gnome.org/GNOME/gnome-shell/-/compare/47.0...48.0?from_project_id=546&page=6). The important file is `
src/_sass/gnome-shell/widgets/_quick-settings-48.scss`. My changes are on the last two `wip` commits.

## Visual Reference

Here's the base fix:

![Screenshot From 2025-03-22 20-02-48](https://github.com/user-attachments/assets/a5ba33af-2c18-41cb-b661-d3f2862e871d)

Notice that new separator there? I didn't know which color to use, so I removed it:

![Screenshot From 2025-03-22 20-05-37](https://github.com/user-attachments/assets/ac63e0d6-9fff-4bf9-aa4b-3919c993f8e4)

Here you can see that the arrow has a different background color from the button when unchecked, but the same color when checked. Since I don't know the colors used before, I decide to just use the button colors for everything. Here's how it looks:

![Screenshot From 2025-03-22 20-06-55](https://github.com/user-attachments/assets/4b84e947-b8a2-4fb7-ad4d-e8e1efe67eb1)

So that's the current state of this fix.